### PR TITLE
feat: Implement InventoryRepository with custom queries

### DIFF
--- a/src/main/java/com/bookstore/management/inventory/repository/InventoryRepository.java
+++ b/src/main/java/com/bookstore/management/inventory/repository/InventoryRepository.java
@@ -1,8 +1,11 @@
 package com.bookstore.management.inventory.repository;
 
 import com.bookstore.management.inventory.model.Inventory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,13 +14,12 @@ import java.util.Optional;
 @Repository
 public interface InventoryRepository extends JpaRepository<Inventory, Long> {
 
-    Optional<Inventory> findByBookId(Long bookId);
+    @Query("select i from Inventory i JOIN FETCH i.book WHERE i.book.id = :bookId")
+    Optional<Inventory> findByBookId(@Param("bookId") Long bookId);
 
-    @Query("select i from Inventory i where i.stockMin > i.quantityAvailable AND i.activeState = true ")
+    @Query("select i from Inventory i JOIN FETCH i.book where i.stockMin > i.quantityAvailable AND i.activeStatus = true")
     List<Inventory> findActiveInventoriesWithLowStock();
 
-    List<Inventory>  findByActiveStateTrue();
-
-    Optional<Inventory> findByBookIsbn(String isbn);
-
+    @Query("select i from Inventory i JOIN FETCH i.book where i.activeStatus = :activeStatus")
+    List<Inventory> findByActiveStatus(@Param("activeStatus") Boolean activeStatus);
 }


### PR DESCRIPTION
## Objetivo
Implementar el InventoryRepository con queries personalizadas para cumplir con los requisitos del issue #13 

## Cambios realizados
- ✅ Creada interface `InventoryRepository` extendiendo `JpaRepository`
- ✅ Implementada query `findByBookId` con JOIN FETCH
- ✅ Implementada query `findActiveInventoriesWithLowStock` para inventarios con stock bajo
- ✅ Implementada query `findByActiveStatus` para filtrar por estado activo/inactivo
- ✅ Utilizado JOIN FETCH para cargar la relación `book` de forma eficiente y evitar N+1 queries

## Decisiones técnicas
- Se utilizó `JOIN FETCH` en lugar de `@EntityGraph` porque no hay paginación implementada aún
- Se priorizó una sola query optimizada por su simplicidad y eficiencia

## ✅ Checklist
- [x] Código implementado
- [x] Queries probadas localmente
- [ ] Tests unitarios (se agregarán en PR futuro)
- [ ] Paginación (feature futuro)

## Relacionado
Closes #13 