### PR TITLE
feat: add InventoryMovementMapper

### DIFF
--- a/src/main/java/com/bookstore/management/inventory/mapper/InventoryMovementMapper.java
+++ b/src/main/java/com/bookstore/management/inventory/mapper/InventoryMovementMapper.java
@@ -4,9 +4,13 @@ import com.bookstore.management.inventory.dto.InventoryMovementResponseDTO;
 import com.bookstore.management.inventory.model.InventoryMovement;
 import org.mapstruct.Mapper;
 
+import java.util.List;
+
 @Mapper(componentModel = "spring", uses = {InventoryMapper.class})
 public interface InventoryMovementMapper {
 
     InventoryMovementResponseDTO toInventoryMovementResponseDTO(InventoryMovement inventoryMovement);
+
+    List<InventoryMovementResponseDTO> toInventoryMovementResponseDTOList(List<InventoryMovement> inventoryMovements);
 
 }

--- a/src/main/java/com/bookstore/management/inventory/repository/InventoryRepository.java
+++ b/src/main/java/com/bookstore/management/inventory/repository/InventoryRepository.java
@@ -1,8 +1,6 @@
 package com.bookstore.management.inventory.repository;
 
 import com.bookstore.management.inventory.model.Inventory;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;


### PR DESCRIPTION
## CheckList

- [x] Crear de la clase InventoryMovementMapper 
- [x] Implementar  toInventoryMovementResponseDTO(InventoryMovement entity)
- [x] Implementar método toInventoryMovementResponseDTOList(List entities)
- [x] Mapear correctamente todos los campos incluyendo relaciones

## Decisiones Tecnicas
- Elimine imports que no se usaban en `InventoryRepository`
- Utilice `componentModel = "spring"` para integración con Spring
- Agregue `InventoryMapper` en el parametro `uses` para reutilizar los mapeos de la relacion inventory -> inventorySummaryDTO

## Relacionado
Resolves #11